### PR TITLE
Install virtual env inside repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,16 @@ To install `kirk`, please consider the following procedure:
     # clone repository
     git clone git@github.com:acerv/kirk.git
 
+    cd kirk
+
     # create virtualenv (python-3.6+)
-    virtualenv venv
+    virtualenv .venv
 
     # activate virtualenv
-    source venv/bin/activate
+    source .venv/bin/activate
 
     # install kirk
-    pip install ./kirk
+    pip install .
 
     # execute kirk
     kirk --help


### PR DESCRIPTION
This tripped me up because I created venv inside the repo dir because I didn't read the instructions properly. I then noticed that the .gitignore has .venv* inside it and actually I'd prefer to have the virtual env inside the repo dir.

Ah I see you keep editing this file, so I'll just make the PR as a suggestion.