### PR TITLE
Fix cgroup kselftests collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,6 @@ install:
 	install -m 00644 $(top_srcdir)/tools/kirk/libkirk/*.py $(BASE_DIR)/libkirk
 	install -m 00775 $(top_srcdir)/tools/kirk/kirk $(BASE_DIR)/kirk
 
+	ln -s $(BASE_DIR)/runltp-ng $(BASE_DIR)/kirk
+
 include $(top_srcdir)/include/mk/generic_leaf_target.mk

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,6 @@ install:
 	install -m 00644 $(top_srcdir)/tools/kirk/libkirk/*.py $(BASE_DIR)/libkirk
 	install -m 00775 $(top_srcdir)/tools/kirk/kirk $(BASE_DIR)/kirk
 
-	ln -s $(BASE_DIR)/runltp-ng $(BASE_DIR)/kirk
+	ln -sf $(BASE_DIR)/runltp-ng $(BASE_DIR)/kirk
 
 include $(top_srcdir)/include/mk/generic_leaf_target.mk

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,6 @@ install:
 	install -m 00644 $(top_srcdir)/tools/kirk/libkirk/*.py $(BASE_DIR)/libkirk
 	install -m 00775 $(top_srcdir)/tools/kirk/kirk $(BASE_DIR)/kirk
 
-	ln -sf $(BASE_DIR)/kirk $(BASE_DIR)/runltp-ng
+	cd $(BASE_DIR) && ln -sf kirk runltp-ng
 
 include $(top_srcdir)/include/mk/generic_leaf_target.mk

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,6 @@ install:
 	install -m 00644 $(top_srcdir)/tools/kirk/libkirk/*.py $(BASE_DIR)/libkirk
 	install -m 00775 $(top_srcdir)/tools/kirk/kirk $(BASE_DIR)/kirk
 
-	ln -sf $(BASE_DIR)/runltp-ng $(BASE_DIR)/kirk
+	ln -sf $(BASE_DIR)/kirk $(BASE_DIR)/runltp-ng
 
 include $(top_srcdir)/include/mk/generic_leaf_target.mk

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Some basic commands are the following:
 
     # run LTP syscalls testing suite via SSH
     ./kirk --framework ltp \
-        --sut=ssh:host myhost.com:user=root:key_file=myhost_id_rsa \
+        --sut ssh:host=myhost.com:user=root:key_file=myhost_id_rsa \
         --run-suite syscalls
 
     # run LTP syscalls testing suite in parallel on host using 16 workers
@@ -101,7 +101,7 @@ Some basic commands are the following:
 
     # run LTP syscalls testing suite in parallel via SSH using 16 workers
     ./kirk --framework ltp \
-        --sut=ssh:host myhost.com:user=root:key_file=myhost_id_rsa \
+        --sut ssh:host=myhost.com:user=root:key_file=myhost_id_rsa \
         --run-suite syscalls --workers 16
 
 It's possible to run a single command before running testing suites using

--- a/libkirk/data.py
+++ b/libkirk/data.py
@@ -122,3 +122,17 @@ class Test:
         Environment variables
         """
         return self._env
+
+    @property
+    def full_command(self):
+        """
+        Return the full command, with arguments as well.
+        For example, if `command="ls"` and `arguments="-l -a"`,
+        `full_command="ls -l -a"`.
+        """
+        cmd = self.command
+        if len(self.arguments) > 0:
+            cmd += ' '
+            cmd += ' '.join(self.arguments)
+
+        return cmd

--- a/libkirk/framework.py
+++ b/libkirk/framework.py
@@ -34,6 +34,19 @@ class Framework(Plugin):
         """
         raise NotImplementedError()
 
+    async def find_command(self, sut: SUT, command: str) -> Test:
+        """
+        Search for command inside Framework folder and, if it's not found,
+        search for command in the operating system. Then return a Test object
+        which can be used to execute command.
+        :param sut: SUT object to communicate with
+        :type sut: SUT
+        :param command: command to execute
+        :type command: str
+        :returns: Test
+        """
+        raise NotImplementedError()
+
     async def find_suite(self, sut: SUT, name: str) -> Suite:
         """
         Search for suite with given name inside SUT.

--- a/libkirk/host.py
+++ b/libkirk/host.py
@@ -144,7 +144,7 @@ class HostSUT(SUT):
         try:
             kwargs = {
                 "stdout": asyncio.subprocess.PIPE,
-                "stderr": asyncio.subprocess.PIPE,
+                "stderr": asyncio.subprocess.STDOUT,
                 "cwd": cwd,
                 "preexec_fn": os.setsid
             }

--- a/libkirk/kselftests.py
+++ b/libkirk/kselftests.py
@@ -6,6 +6,7 @@
 .. moduleauthor:: Andrea Cervesato <andrea.cervesato@suse.com>
 """
 import os
+import shlex
 import logging
 from libkirk import KirkException
 from libkirk.sut import SUT
@@ -115,6 +116,43 @@ class KselftestFramework(Framework):
             raise ValueError("SUT is None")
 
         return ["cgroup", "bpf"]
+
+    async def find_command(self, sut: SUT, command: str) -> Test:
+        if not sut:
+            raise ValueError("SUT is None")
+
+        if not command:
+            raise ValueError("command is empty")
+
+        cmd_args = shlex.split(command)
+        suite_folder = None
+
+        for suite in await self.get_suites(sut):
+            folder = os.path.join(self._root, suite)
+            binary = os.path.join(folder, cmd_args[0])
+
+            ret = await sut.run_command(f"test -f {binary}")
+            if ret["returncode"] == 0:
+                suite_folder = folder
+                break
+
+        cwd = None
+        env = None
+
+        ret = await sut.run_command(f"test -d {suite_folder}")
+        if ret["returncode"] == 0:
+            cwd = suite_folder
+            env={"PATH": suite_folder}
+
+        test = Test(
+            name=cmd_args[0],
+            cmd=cmd_args[0],
+            args=cmd_args[1:] if len(cmd_args) > 0 else None,
+            cwd=cwd,
+            env=env,
+            parallelizable=False)
+
+        return test
 
     async def find_suite(self, sut: SUT, name: str) -> Suite:
         if not sut:

--- a/libkirk/ltp.py
+++ b/libkirk/ltp.py
@@ -154,7 +154,7 @@ class LTPFramework(Framework):
 
             self._logger.debug("Test declaration: %s", line)
 
-            parts = line.split()
+            parts = shlex.split(line)
             if len(parts) < 2:
                 raise FrameworkError(
                     "runtest file is not defining test command")

--- a/libkirk/scheduler.py
+++ b/libkirk/scheduler.py
@@ -131,18 +131,6 @@ class TestScheduler(Scheduler):
         if not self._framework:
             raise ValueError("Framework object is empty")
 
-    @ staticmethod
-    def _command_from_test(test: Test) -> str:
-        """
-        Returns a command from test.
-        """
-        cmd = test.command
-        if len(test.arguments) > 0:
-            cmd += ' '
-            cmd += ' '.join(test.arguments)
-
-        return cmd
-
     async def _get_tainted_status(self) -> tuple:
         """
         Check tainted status of the Kernel.
@@ -220,7 +208,7 @@ class TestScheduler(Scheduler):
             await self._write_kmsg(test)
 
             iobuffer = RedirectTestStdout(test)
-            cmd = self._command_from_test(test)
+            cmd = test.full_command
             start_t = time.time()
             exec_time = 0
             test_data = None

--- a/libkirk/scheduler.py
+++ b/libkirk/scheduler.py
@@ -155,13 +155,8 @@ class TestScheduler(Scheduler):
             self._logger.info("Can't write on /dev/kmsg from user")
             return
 
-        cmd = f"{test.command}"
-        if len(test.arguments) > 0:
-            cmd += ' '
-            cmd += ' '.join(test.arguments)
-
         message = f'{sys.argv[0]}[{os.getpid()}]: ' \
-            f'starting test {test.name} ({cmd})\n'
+            f'starting test {test.name} ({test.full_command})\n'
 
         await self._sut.run_command(f'echo -n "{message}" > /dev/kmsg')
 
@@ -261,7 +256,7 @@ class TestScheduler(Scheduler):
             if status not in [self.STATUS_OK, self.KERNEL_TAINED]:
                 test_data = {
                     "name": test.name,
-                    "command": test.command,
+                    "command": test.full_command,
                     "stdout": iobuffer.stdout,
                     "returncode": -1,
                     "exec_time": exec_time,

--- a/libkirk/session.py
+++ b/libkirk/session.py
@@ -306,6 +306,11 @@ class Session:
         async with self._run_lock:
             await libkirk.events.fire("session_started", self._tmpdir.abspath)
 
+            if not self._sut.parallel_execution:
+                await libkirk.events.fire(
+                    "session_warning",
+                    "SUT doesn't support parallel execution")
+
             try:
                 await self._start_sut()
 

--- a/libkirk/session.py
+++ b/libkirk/session.py
@@ -235,9 +235,13 @@ class Session:
             try:
                 await libkirk.events.fire("run_cmd_start", command)
 
+                test = await self._framework.find_command(self._sut, command)
+
                 ret = await asyncio.wait_for(
                     self._sut.run_command(
-                        command,
+                        test.full_command,
+                        cwd=test.cwd,
+                        env=test.env,
                         iobuffer=RedirectSUTStdout(self._sut, True)),
                     timeout=self._exec_timeout
                 )

--- a/libkirk/sut.py
+++ b/libkirk/sut.py
@@ -253,7 +253,13 @@ class SUT(Plugin):
             stdout = ret["stdout"].rstrip()
 
             tainted_num = len(TAINED_MSG)
-            code = int(stdout.rstrip())
+            code = stdout.rstrip()
+
+            # output is likely message in stderr
+            if not code.isdigit():
+                raise SUTError(code)
+
+            code = int(code)
             bits = format(code, f"0{tainted_num}b")[::-1]
 
             messages = []

--- a/libkirk/tests/conftest.py
+++ b/libkirk/tests/conftest.py
@@ -48,6 +48,9 @@ class DummyFramework(Framework):
     async def get_suites(self, sut: SUT) -> list:
         return ["suite01", "suite02", "sleep", "environ", "kernel_panic"]
 
+    async def find_command(self, sut: SUT, command: str) -> Test:
+        return Test(name=command, cmd=command)
+
     async def find_suite(self, sut: SUT, name: str) -> Suite:
         if name in "suite01":
             test0 = Test(

--- a/libkirk/tests/test_kselftests.py
+++ b/libkirk/tests/test_kselftests.py
@@ -89,6 +89,18 @@ class TestKselftestsFramework:
         suites = await framework.get_suites(sut)
         assert suites == self.GROUPS
 
+    async def test_find_command(self, framework, sut, tmpdir):
+        """
+        Test find_command method.
+        """
+        test = await framework.find_command(sut, "test_progs")
+        assert test.name == "test_progs"
+        assert test.command == "test_progs"
+        assert not test.arguments
+        assert not test.parallelizable
+        assert test.env == {"PATH": str(tmpdir / "bpf")}
+        assert test.cwd == str(tmpdir / "bpf")
+
     async def test_find_suite(self, framework, sut, tmpdir):
         """
         Test find_suite method.

--- a/libkirk/tests/test_liburing.py
+++ b/libkirk/tests/test_liburing.py
@@ -66,6 +66,18 @@ class TestLiburing:
         suites = await framework.get_suites(sut)
         assert suites == ["default"]
 
+    async def test_find_command(self, framework, sut, tmpdir):
+        """
+        Test find_command method.
+        """
+        test = await framework.find_command(sut, "test0 ciao bepi")
+        assert test.name == "test0"
+        assert test.command == "test0"
+        assert test.arguments == ["ciao", "bepi"]
+        assert not test.parallelizable
+        assert test.env == {"PATH": str(tmpdir)}
+        assert test.cwd == str(tmpdir)
+
     async def test_find_suite(self, framework, sut, tmpdir):
         """
         Test find_suite method.

--- a/libkirk/tests/test_ltp.py
+++ b/libkirk/tests/test_ltp.py
@@ -50,7 +50,7 @@ class TestLTPFramework:
         for i in range(self.TESTS_NUM):
             content += f"test0{i} echo ciao\n"
 
-        tmpdir.mkdir("testcases").mkdir("bin")
+        testcases = tmpdir.mkdir("testcases").mkdir("bin")
         runtest = tmpdir.mkdir("runtest")
 
         for i in range(self.SUITES_NUM):
@@ -75,6 +75,10 @@ class TestLTPFramework:
         metadata = tmpdir.mkdir("metadata") / "ltp.json"
         metadata.write(json.dumps(metadata_d))
 
+        # create shell test
+        test_sh = testcases / "test.sh"
+        test_sh.write("#!/bin/bash\necho $1 $2\n")
+
     def test_name(self, framework):
         """
         Test that name property is not empty.
@@ -90,6 +94,18 @@ class TestLTPFramework:
         assert "suite1" in suites
         assert "suite2" in suites
         assert "slow_suite" in suites
+
+    async def test_find_command(self, framework, sut, tmpdir):
+        """
+        Test find_command method.
+        """
+        test = await framework.find_command(sut, "test.sh ciao bepi")
+        assert test.name == "test.sh"
+        assert test.command == "test.sh"
+        assert test.arguments == ["ciao", "bepi"]
+        assert not test.parallelizable
+        assert test.cwd == tmpdir / "testcases" / "bin"
+        assert test.env
 
     async def test_find_suite(self, framework, sut, tmpdir):
         """

--- a/libkirk/ui.py
+++ b/libkirk/ui.py
@@ -272,7 +272,7 @@ class VerboseUserInterface(ConsoleUserInterface):
         self._print(test.name, color=self.CYAN, end="")
         self._print(" =====")
         self._print("command: ", end="")
-        self._print(f"{test.command} {' '.join(test.arguments)}")
+        self._print(test.full_command)
 
     async def test_completed(self, results: TestResults) -> None:
         if self._timed_out:

--- a/libkirk/ui.py
+++ b/libkirk/ui.py
@@ -46,6 +46,7 @@ class ConsoleUserInterface:
         libkirk.events.register("run_cmd_stop", self.run_cmd_stop)
         libkirk.events.register("suite_started", self.suite_started)
         libkirk.events.register("suite_completed", self.suite_completed)
+        libkirk.events.register("session_warning", self.session_warning)
         libkirk.events.register("session_error", self.session_error)
         libkirk.events.register("internal_error", self.internal_error)
 
@@ -157,6 +158,9 @@ class ConsoleUserInterface:
         self._print(
             f"Suite '{suite.name}' timed out after {timeout} seconds",
             color=self.RED)
+
+    async def session_warning(self, msg: str) -> None:
+        self._print(f"Warning: {msg}", color=self.YELLOW)
 
     async def session_error(self, error: str) -> None:
         self._print(f"Error: {error}", color=self.RED)


### PR DESCRIPTION
This patch filters out kselftests binaries using python regexp, instead of using a bash script.